### PR TITLE
Adding JS object as an export format

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,23 @@
+const StyleDictionary = require('style-dictionary');
+
+console.log('Build started...');
+console.log('\n==============================================');
+
+// Register Custom Filters
+StyleDictionary.registerFilter({
+  name: 'isColor',
+  matcher: (prop) => prop.attributes.category === 'color',
+});
+
+// APPLY THE CONFIGURATION
+// IMPORTANT: the registration of custom transforms
+// needs to be done _before_ applying the configuration
+StyleDictionaryExtended = StyleDictionary.extend('./config.json');
+
+
+// FINALLY, BUILD ALL THE PLATFORMS
+StyleDictionaryExtended.buildAllPlatforms();
+
+
+console.log('\n==============================================');
+console.log('\nBuild completed!');

--- a/config.json
+++ b/config.json
@@ -5,8 +5,9 @@
       "transformGroup": "scss",
       "buildPath": "build/scss/",
       "files": [{
-        "destination": "tokens.scss",
-        "format": "scss/variables"
+        "destination": "colors.scss",
+        "format": "scss/variables",
+        "filter": "isColor"
       }]
     },
     "css": {
@@ -14,8 +15,18 @@
       "buildPath": "build/css/",
       "files": [
         {
-          "destination": "tokens.css",
-          "format": "css/variables"
+          "destination": "colors.css",
+          "format": "css/variables",
+          "filter": "isColor"
+        }
+      ]
+    },
+    "js": {
+      "buildPath": "build/js/",
+      "files": [
+        {
+          "destination": "colors.js",
+          "format": "javascript/module"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "properties"
   ],
   "scripts": {
-    "build": "node_modules/.bin/style-dictionary build",
+    "build": "node build.js",
     "clean": "rm -rf build",
     "prepublishOnly": "yarn build"
   },


### PR DESCRIPTION
This allows us to use our style dictionary object tree to create documentation.
Also separated out colors into their own output file, ideally we can keep all these modules separated in the future.