### PR TITLE
Breakpoints

### DIFF
--- a/build.js
+++ b/build.js
@@ -25,6 +25,11 @@ StyleDictionary.registerFilter({
 });
 
 StyleDictionary.registerFilter({
+  name: 'isCategorySizeAndTypeBreakpoint',
+  matcher: (prop) => prop.attributes.category === 'size' && prop.attributes.type === 'breakpoint',
+});
+
+StyleDictionary.registerFilter({
   name: 'isNotTypeBase',
   matcher: (prop) => prop.attributes.type !== 'base',
 });

--- a/build.js
+++ b/build.js
@@ -14,26 +14,6 @@ StyleDictionary.registerFilter({
   matcher: (prop) => prop.attributes.category === 'size',
 });
 
-StyleDictionary.registerFilter({
-  name: 'isCategorySizeAndTypeFont',
-  matcher: (prop) => prop.attributes.category === 'size' && prop.attributes.type === 'font',
-});
-
-StyleDictionary.registerFilter({
-  name: 'isCategorySizeAndTypeBorderRadius',
-  matcher: (prop) => prop.attributes.category === 'size' && prop.attributes.type === 'border-radius',
-});
-
-StyleDictionary.registerFilter({
-  name: 'isCategorySizeAndTypeBreakpoint',
-  matcher: (prop) => prop.attributes.category === 'size' && prop.attributes.type === 'breakpoint',
-});
-
-StyleDictionary.registerFilter({
-  name: 'isNotTypeBase',
-  matcher: (prop) => prop.attributes.type !== 'base',
-});
-
 var utilities = [{
     "name": "font-color",
     "tokenCategory": "color",
@@ -87,7 +67,7 @@ const spacingUtilities = [{
 
 StyleDictionary.registerFormat({
   name: 'utilityClass',
-  formatter: function (dictionary, platform) {
+  formatter: function (dictionary) {
     let output = '';
     dictionary.allProperties.forEach(prop => {
       const tokenCategory = prop.attributes.category;
@@ -140,6 +120,17 @@ StyleDictionary.registerFormat({
 
     return output;
   }
+});
+
+StyleDictionary.registerTransform({
+  name: 'size/use-unit',
+  type: 'value',
+  matcher: function(prop) {
+    return prop.attributes.category === 'size';
+  },
+  transformer: function(prop) {
+    return prop.original.value + prop.original.unit;
+  },
 });
 
 // APPLY THE CONFIGURATION

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "source": ["properties/**/*.json"],
   "platforms": {
     "scss": {
-      "transformGroup": "scss",
+      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "buildPath": "build/scss/",
       "files": [{
         "destination": "variables-color.scss",
@@ -15,7 +15,7 @@
       }]
     },
     "css": {
-      "transformGroup": "css",
+      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "buildPath": "build/css/",
       "files": [{
         "destination": "variables-color.css",
@@ -29,7 +29,7 @@
     },
     "cssUtilities": {
       "buildPath": "build/utilities/",
-      "transformGroup": "css",
+      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "files": [{
         "destination": "utilities-size.css",
         "format": "utilityClass",
@@ -42,7 +42,7 @@
     },
     "sassUtilities": {
       "buildPath": "build/utilities/",
-      "transformGroup": "scss",
+      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "files": [{
         "destination": "utilities-size.scss",
         "format": "utilityClass",
@@ -54,7 +54,7 @@
       }]
     },
     "js": {
-      "transformGroup": "js",
+      "transforms": ["attribute/cti", "name/cti/pascal", "size/use-unit", "color/hex"],
       "buildPath": "build/js/",
       "files": [{
         "destination": "variables-color.js",
@@ -67,7 +67,7 @@
       }]
     },
     "json": {
-      "transformGroup": "js",
+      "transforms": ["attribute/cti", "name/cti/pascal", "size/use-unit", "color/hex"],
       "buildPath": "build/json/",
       "files": [{
         "destination": "variables-color.json",

--- a/properties/size/border-radius.json
+++ b/properties/size/border-radius.json
@@ -1,10 +1,11 @@
 {
   "size": {
     "border-radius": {
-      "xs": { "value": "0.125" },
-      "sm": { "value": "0.25" },
-      "md": { "value": ".5" },
-      "lg": { "value": "1" }
+      "xs": { "value": "0.125", "unit": "rem" },
+      "sm": { "value": "0.25", "unit": "rem" },
+      "md": { "value": ".5", "unit": "rem" },
+      "lg": { "value": "1", "unit": "rem" },
+      "circle": { "value": "50", "unit": "%" }
     }
   }
 }

--- a/properties/size/breakpoint.json
+++ b/properties/size/breakpoint.json
@@ -1,22 +1,17 @@
 {
   "size": {
     "breakpoint": {
-      "sm": {
-        "value": "576",
-        "comment": "small devices, landscape phones and larger",
+      "tablet": {
+        "value": "608",
+        "comment": "landscape phones, tablets and larger",
         "unit": "px"
       },
-      "md": {
-        "value": "768",
-        "comment": "tablets and larger",
-        "unit": "px"
-      },
-      "lg": {
+      "desktop": {
         "value": "992",
         "comment": "landscape tablets, desktops and larger",
         "unit": "px"
       },
-      "xl": {
+      "hd": {
         "value": "1280",
         "comment": "large desktops and larger",
         "unit": "px"

--- a/properties/size/breakpoint.json
+++ b/properties/size/breakpoint.json
@@ -3,19 +3,23 @@
     "breakpoint": {
       "phone": {
         "value": "480",
-        "comment": "devices smaller than tablets"
+        "comment": "devices smaller than tablets",
+        "unit": "px"
       },
       "tablet": {
         "value": "768",
-        "comment": "devices larger than phone"
+        "comment": "devices larger than phone",
+        "unit": "px"
       },
       "desktop": {
         "value": "1024",
-        "comment": "devices larger than tablet"
+        "comment": "devices larger than tablet",
+        "unit": "px"
       },
       "hd": {
-        "value": "1440px",
-        "comment": "devices with high resolution displays"
+        "value": "1440",
+        "comment": "devices with high resolution displays",
+        "unit": "px"
       }
     }
   }

--- a/properties/size/breakpoint.json
+++ b/properties/size/breakpoint.json
@@ -1,0 +1,22 @@
+{
+  "size": {
+    "breakpoint": {
+      "sm": {
+        "value": "30",
+        "comment": "480px, devices smaller than tablets"
+      },
+      "md": {
+        "value": "48",
+        "comment": "768px, devices larger than phone"
+      },
+      "lg": {
+        "value": "64",
+        "comment": "1024px, devices larger than tablet"
+      },
+      "xl": {
+        "value": "90",
+        "comment": "1440px, devices with high resolution displays"
+      }
+    }
+  }
+}

--- a/properties/size/breakpoint.json
+++ b/properties/size/breakpoint.json
@@ -1,24 +1,24 @@
 {
   "size": {
     "breakpoint": {
-      "phone": {
-        "value": "480",
-        "comment": "viewports smaller than tablets",
+      "sm": {
+        "value": "576",
+        "comment": "small devices, landscape phones",
         "unit": "px"
       },
-      "tablet": {
+      "md": {
         "value": "768",
-        "comment": "viewports larger than phone",
+        "comment": "tablets",
         "unit": "px"
       },
-      "desktop": {
-        "value": "1024",
-        "comment": "viewports larger than tablet",
+      "lg": {
+        "value": "992",
+        "comment": "landscape tablets, desktops",
         "unit": "px"
       },
-      "hd": {
-        "value": "1440",
-        "comment": "viewports with high resolution",
+      "xl": {
+        "value": "1280",
+        "comment": "large desktops",
         "unit": "px"
       }
     }

--- a/properties/size/breakpoint.json
+++ b/properties/size/breakpoint.json
@@ -3,22 +3,22 @@
     "breakpoint": {
       "phone": {
         "value": "480",
-        "comment": "devices smaller than tablets",
+        "comment": "viewports smaller than tablets",
         "unit": "px"
       },
       "tablet": {
         "value": "768",
-        "comment": "devices larger than phone",
+        "comment": "viewports larger than phone",
         "unit": "px"
       },
       "desktop": {
         "value": "1024",
-        "comment": "devices larger than tablet",
+        "comment": "viewports larger than tablet",
         "unit": "px"
       },
       "hd": {
         "value": "1440",
-        "comment": "devices with high resolution displays",
+        "comment": "viewports with high resolution",
         "unit": "px"
       }
     }

--- a/properties/size/breakpoint.json
+++ b/properties/size/breakpoint.json
@@ -3,22 +3,22 @@
     "breakpoint": {
       "sm": {
         "value": "576",
-        "comment": "small devices, landscape phones",
+        "comment": "small devices, landscape phones and larger",
         "unit": "px"
       },
       "md": {
         "value": "768",
-        "comment": "tablets",
+        "comment": "tablets and larger",
         "unit": "px"
       },
       "lg": {
         "value": "992",
-        "comment": "landscape tablets, desktops",
+        "comment": "landscape tablets, desktops and larger",
         "unit": "px"
       },
       "xl": {
         "value": "1280",
-        "comment": "large desktops",
+        "comment": "large desktops and larger",
         "unit": "px"
       }
     }

--- a/properties/size/breakpoint.json
+++ b/properties/size/breakpoint.json
@@ -1,21 +1,21 @@
 {
   "size": {
     "breakpoint": {
-      "sm": {
-        "value": "30",
-        "comment": "480px, devices smaller than tablets"
+      "phone": {
+        "value": "480",
+        "comment": "devices smaller than tablets"
       },
-      "md": {
-        "value": "48",
-        "comment": "768px, devices larger than phone"
+      "tablet": {
+        "value": "768",
+        "comment": "devices larger than phone"
       },
-      "lg": {
-        "value": "64",
-        "comment": "1024px, devices larger than tablet"
+      "desktop": {
+        "value": "1024",
+        "comment": "devices larger than tablet"
       },
-      "xl": {
-        "value": "90",
-        "comment": "1440px, devices with high resolution displays"
+      "hd": {
+        "value": "1440px",
+        "comment": "devices with high resolution displays"
       }
     }
   }

--- a/properties/size/font.json
+++ b/properties/size/font.json
@@ -3,36 +3,46 @@
     "font": {
       "xs": {
         "value": "0.75",
-        "comment": "Small and hard to read for many people so use with caution"
+        "comment": "Small and hard to read for many people so use with caution",
+        "unit": "rem"
       },
       "sm": {
-        "value": "0.875"
+        "value": "0.875",
+        "unit": "rem"
       },
       "md": {
         "value": "1",
-        "comment": "For paragraph body copy"
+        "comment": "For paragraph body copy",
+        "unit": "rem"
       },
       "lg": {
-        "value": "1.25"
+        "value": "1.25",
+        "unit": "rem"
       },
       "xl": {
-        "value": "1.5"
+        "value": "1.5",
+        "unit": "rem"
       },
       "2xl": {
-        "value": "2.25"
+        "value": "2.25",
+        "unit": "rem"
       },
       "3xl": {
-        "value": "3"
+        "value": "3",
+        "unit": "rem"
       },
       "4xl": {
-        "value": "5"
+        "value": "5",
+        "unit": "rem"
       },
       "5xl": {
         "value": "6",
-        "comment": "For Hero or Marketing titles"
+        "comment": "For Hero or Marketing titles",
+        "unit": "rem"
       },
       "base": {
-          "value": "{size.font.md.value}"
+          "value": "{size.font.md.value}",
+          "unit": "rem"
       }
     }
   }

--- a/properties/size/spacing.json
+++ b/properties/size/spacing.json
@@ -1,17 +1,17 @@
 {
   "size": {
     "spacing": {
-      "2xs": { "value": "0.25" },
-      "xs": { "value": "0.5" },
-      "sm": { "value": "0.75" },
-      "md": { "value": "1" },
-      "lg": { "value": "1.5" },
-      "xl": { "value": "2" },
-      "2xl": { "value": "2.5" },
-      "3xl": { "value": "3" },
-      "4xl": { "value": "4" },
-      "5xl": { "value": "5" },
-      "base": { "value": "{size.spacing.md.value}" }
+      "2xs": { "value": "0.25", "unit": "rem" },
+      "xs": { "value": "0.5", "unit": "rem" },
+      "sm": { "value": "0.75", "unit": "rem" },
+      "md": { "value": "1", "unit": "rem" },
+      "lg": { "value": "1.5", "unit": "rem" },
+      "xl": { "value": "2", "unit": "rem" },
+      "2xl": { "value": "2.5", "unit": "rem" },
+      "3xl": { "value": "3", "unit": "rem" },
+      "4xl": { "value": "4", "unit": "rem" },
+      "5xl": { "value": "5", "unit": "rem" },
+      "base": { "value": "{size.spacing.md.value}", "unit": "rem" }
     }
   }
 }


### PR DESCRIPTION
This PR sets the following min-width breakpoint tokens:

tablet: 608px
desktop: 992px
hd: 1280px

result of this change for css vars:
```
  --size-breakpoint-tablet: 608px; /* , landscape phones, tablets and larger */
  --size-breakpoint-desktop: 992px; /* landscape tablets, desktops and larger */
  --size-breakpoint-hd: 1280px; /* large desktops and larger */
```

to do:

- [x] set `yarn build` output breakpoint values as `px` instead of `rem` when 