### PR TITLE
adding spacing utilities

### DIFF
--- a/build.js
+++ b/build.js
@@ -115,9 +115,9 @@ StyleDictionary.registerFormat({
               if (variation === 'all') {
                 output += `.${utilityClass} { ${property}: ${prop.value} }\n\n`; 
               } else if (variation === 'x') {
-                output += `.${utilityClass} { ${property}: 0 ${prop.value} 0 ${prop.value} }\n\n`; 
+                output += `.${utilityClass} { ${property}: 0 ${prop.value} }\n\n`; 
               } else if (variation === 'y') {
-                output += `.${utilityClass} { ${property}: ${prop.value} 0 ${prop.value} 0 }\n\n`; 
+                output += `.${utilityClass} { ${property}: ${prop.value} 0 }\n\n`; 
               }
             }
           });

--- a/build.js
+++ b/build.js
@@ -61,21 +61,66 @@ var utilities = [{
   },
 ];
 
+const spacingUtilities = [
+  {
+    "name": "margin",
+    "abbreviation": "m",
+    "tokenCategory": "size",
+    "tokenType": "spacing",
+    "CSSprop": "margin",
+    "variations": ["all", "top", "right", "bottom", "left", "x", "y"],
+  },
+  {
+    "name": "padding",
+    "abbreviation": "p",
+    "tokenCategory": "size",
+    "tokenType": "spacing",
+    "CSSprop": "padding",
+    "variations": ["all", "top", "right", "bottom", "left", "x", "y"],
+  },
+]
+
 
 StyleDictionary.registerFormat({
   name: 'utilityClass',
   formatter: function (dictionary, platform) {
     let output = '';
-    dictionary.allProperties.forEach(function (prop) {
+    dictionary.allProperties.forEach(prop => {
       const tokenCategory = prop.attributes.category;
       const tokenType = prop.attributes.type;
-      utilities.forEach(function (utility) {
+
+      utilities.forEach(utility => {
         if (tokenCategory === utility.tokenCategory && tokenType === utility.tokenType) {
           let utilityClass = `${utility.name}-${prop.attributes.item}`;
           if (prop.attributes.subitem && prop.attributes.subitem !== 'base') {
             utilityClass += `-${prop.attributes.subitem}`;
           }
-          output += `.${utilityClass} { ${utility.CSSprop}: ${prop.value} }\n\n`
+          output += `.${utilityClass} { ${utility.CSSprop}: ${prop.value} }\n\n`;
+        }
+      });
+
+      spacingUtilities.forEach(utility => {
+        if (tokenCategory === utility.tokenCategory && tokenType === utility.tokenType) {
+          const single = ['top', 'right', 'bottom', 'left'];
+          const compound = ['all', 'x', 'y'];
+          utility.variations.forEach(variation => {
+            let property;
+            let utilityClass = `${utility.abbreviation}-${variation}-${prop.attributes.item}`;
+            if (single.includes(variation)) {
+              property = `${utility.name}-${variation}`;
+              output += `.${utilityClass} { ${property}: ${prop.value} }\n\n`;
+            }
+            else if (compound.includes(variation)) {
+              property = utility.name;
+              if (variation === 'all') {
+                output += `.${utilityClass} { ${property}: ${prop.value} }\n\n`; 
+              } else if (variation === 'x') {
+                output += `.${utilityClass} { ${property}: 0 ${prop.value} 0 ${prop.value} }\n\n`; 
+              } else if (variation === 'y') {
+                output += `.${utilityClass} { ${property}: ${prop.value} 0 ${prop.value} 0 }\n\n`; 
+              }
+            }
+          });
         }
       });
     });

--- a/build.js
+++ b/build.js
@@ -68,7 +68,7 @@ const spacingUtilities = [
     "tokenCategory": "size",
     "tokenType": "spacing",
     "CSSprop": "margin",
-    "variations": ["all", "top", "right", "bottom", "left", "x", "y"],
+    "variations": ["", "top", "right", "bottom", "left", "x", "y"],
   },
   {
     "name": "padding",
@@ -76,7 +76,7 @@ const spacingUtilities = [
     "tokenCategory": "size",
     "tokenType": "spacing",
     "CSSprop": "padding",
-    "variations": ["all", "top", "right", "bottom", "left", "x", "y"],
+    "variations": ["", "top", "right", "bottom", "left", "h", "v"],
   },
 ]
 
@@ -89,6 +89,7 @@ StyleDictionary.registerFormat({
       const tokenCategory = prop.attributes.category;
       const tokenType = prop.attributes.type;
 
+      // Most utilities that follow standard patterns. 
       utilities.forEach(utility => {
         if (tokenCategory === utility.tokenCategory && tokenType === utility.tokenType) {
           let utilityClass = `${utility.name}-${prop.attributes.item}`;
@@ -99,24 +100,32 @@ StyleDictionary.registerFormat({
         }
       });
 
+      // Spacing utilities which follow specific patterns with multiple variations
       spacingUtilities.forEach(utility => {
         if (tokenCategory === utility.tokenCategory && tokenType === utility.tokenType) {
-          const single = ['top', 'right', 'bottom', 'left'];
-          const compound = ['all', 'x', 'y'];
+          const single = ['top', 'right', 'bottom', 'left']; // CSS Atribute specifies the variation. E.G: 'margin-bottom: <value>'
+          const compound = ['all', 'h', 'v']; // CSS Attribute applied to multiple sides of an element: E.G: 'margin: <value> <value>'
+
+          // Iterate through variations
           utility.variations.forEach(variation => {
             let property;
-            let utilityClass = `${utility.abbreviation}-${variation}-${prop.attributes.item}`;
+            let utilityClass;
+
+            // Name the class with it's variation
+            if (variation) utilityClass = `${utility.abbreviation}-${variation}-${prop.attributes.item}`;
+            else utilityClass = `${utility.abbreviation}-${prop.attributes.item}`;
+
+            // For specific sides of an element
             if (single.includes(variation)) {
               property = `${utility.name}-${variation}`;
               output += `.${utilityClass} { ${property}: ${prop.value} }\n\n`;
-            }
-            else if (compound.includes(variation)) {
+            } else if (compound.includes(variation)) { // For values applied to multiple sides.
               property = utility.name;
               if (variation === 'all') {
                 output += `.${utilityClass} { ${property}: ${prop.value} }\n\n`; 
-              } else if (variation === 'x') {
+              } else if (variation === 'h') {
                 output += `.${utilityClass} { ${property}: 0 ${prop.value} }\n\n`; 
-              } else if (variation === 'y') {
+              } else if (variation === 'v') {
                 output += `.${utilityClass} { ${property}: ${prop.value} 0 }\n\n`; 
               }
             }


### PR DESCRIPTION
This will add spacing utility classes for margin and padding. Let me know if you are OK with the naming on these. I have the following variations:

* all
* top
* right
* bottom
* left
* x (horizontal)
* y (vertical)

margin and padding are abbreviated as m and p respectively, so the final class names look like this:

```.
m-bottom-md: { margin-bottom: 1rem; }
p-x-lg: { padding: 0 1.5rem; }
m-all-sm: { margin: 0.75rem; }
...etc
```
