### PR TITLE
Add JSON output to the build folder

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,7 +66,7 @@
         "filter": "isCategorySize"
       }]
     },
-    "web": {
+    "json": {
       "transformGroup": "js",
       "buildPath": "build/json/",
       "files": [{
@@ -81,4 +81,3 @@
     }
   }
 }
-

--- a/config.json
+++ b/config.json
@@ -1,84 +1,84 @@
 {
-    "source": ["properties/**/*.json"],
-    "platforms": {
-      "scss": {
-        "transformGroup": "scss",
-        "buildPath": "build/scss/",
-        "files": [{
-          "destination": "variables-color.scss",
-          "format": "scss/variables",
-          "filter": "isCategoryColor"
-        }, {
-          "destination": "variables-size.scss",
-          "format": "scss/variables",
-          "filter": "isCategorySize"
-        }]
-      },
-      "css": {
-        "transformGroup": "css",
-        "buildPath": "build/css/",
-        "files": [{
-          "destination": "variables-color.css",
-          "format": "css/variables",
-          "filter": "isCategoryColor"
-        }, {
-          "destination": "variables-size.css",
-          "format": "css/variables",
-          "filter": "isCategorySize"
-        }]
-      },
-      "cssUtilities": {
-        "buildPath": "build/utilities/",
-        "transformGroup": "css",
-        "files": [{
-          "destination": "utilities-size.css",
-          "format": "utilityClass",
-          "filter": "isCategorySize"
-        }, {
-          "destination": "utilities-color.css",
-          "format": "utilityClass",
-          "filter": "isCategoryColor"
-        }]
-      },
-      "sassUtilities": {
-        "buildPath": "build/utilities/",
-        "transformGroup": "scss",
-        "files": [{
-          "destination": "utilities-size.scss",
-          "format": "utilityClass",
-          "filter": "isCategorySize"
-        }, {
-          "destination": "utilities-color.scss",
-          "format": "utilityClass",
-          "filter": "isCategoryColor"
-        }]
-      },
-      "js": {
-        "transformGroup": "js",
-        "buildPath": "build/js/",
-        "files": [{
-          "destination": "variables-color.js",
-          "format": "javascript/module",
-          "filter": "isCategoryColor"
-        }, {
-          "destination": "variables-size.js",
-          "format": "javascript/module",
-          "filter": "isCategorySize"
-        }]
-      },
-      "web": {
-        "transformGroup": "js",
-        "buildPath": "build/json/",
-        "files": [{
-          "destination": "variables-color.json",
-          "format": "json",
-          "filter": "isCategoryColor"
-        }, {
-          "destination": "variables-size.json",
-          "format": "json",
-          "filter": "isCategorySize"
-        }]
-      }
+  "source": ["properties/**/*.json"],
+  "platforms": {
+    "scss": {
+      "transformGroup": "scss",
+      "buildPath": "build/scss/",
+      "files": [{
+        "destination": "variables-color.scss",
+        "format": "scss/variables",
+        "filter": "isCategoryColor"
+      }, {
+        "destination": "variables-size.scss",
+        "format": "scss/variables",
+        "filter": "isCategorySize"
+      }]
+    },
+    "css": {
+      "transformGroup": "css",
+      "buildPath": "build/css/",
+      "files": [{
+        "destination": "variables-color.css",
+        "format": "css/variables",
+        "filter": "isCategoryColor"
+      }, {
+        "destination": "variables-size.css",
+        "format": "css/variables",
+        "filter": "isCategorySize"
+      }]
+    },
+    "cssUtilities": {
+      "buildPath": "build/utilities/",
+      "transformGroup": "css",
+      "files": [{
+        "destination": "utilities-size.css",
+        "format": "utilityClass",
+        "filter": "isCategorySize"
+      }, {
+        "destination": "utilities-color.css",
+        "format": "utilityClass",
+        "filter": "isCategoryColor"
+      }]
+    },
+    "sassUtilities": {
+      "buildPath": "build/utilities/",
+      "transformGroup": "scss",
+      "files": [{
+        "destination": "utilities-size.scss",
+        "format": "utilityClass",
+        "filter": "isCategorySize"
+      }, {
+        "destination": "utilities-color.scss",
+        "format": "utilityClass",
+        "filter": "isCategoryColor"
+      }]
+    },
+    "js": {
+      "transformGroup": "js",
+      "buildPath": "build/js/",
+      "files": [{
+        "destination": "variables-color.js",
+        "format": "javascript/module",
+        "filter": "isCategoryColor"
+      }, {
+        "destination": "variables-size.js",
+        "format": "javascript/module",
+        "filter": "isCategorySize"
+      }]
+    },
+    "web": {
+      "transformGroup": "js",
+      "buildPath": "build/json/",
+      "files": [{
+        "destination": "variables-color.json",
+        "format": "json",
+        "filter": "isCategoryColor"
+      }, {
+        "destination": "variables-size.json",
+        "format": "json",
+        "filter": "isCategorySize"
+      }]
     }
   }
-  
+}
+

--- a/config.json
+++ b/config.json
@@ -1,101 +1,84 @@
 {
-  "source": ["properties/**/*.json"],
-  "platforms": {
-    "scss": {
-      "transformGroup": "scss",
-      "buildPath": "build/scss/",
-      "files": [
-        {
+    "source": ["properties/**/*.json"],
+    "platforms": {
+      "scss": {
+        "transformGroup": "scss",
+        "buildPath": "build/scss/",
+        "files": [{
           "destination": "variables-color.scss",
           "format": "scss/variables",
           "filter": "isCategoryColor"
-        },
-        {
+        }, {
           "destination": "variables-size.scss",
           "format": "scss/variables",
           "filter": "isCategorySize"
-        }
-      ]
-    },
-    "css": {
-      "transformGroup": "css",
-      "buildPath": "build/css/",
-      "files": [
-        {
+        }]
+      },
+      "css": {
+        "transformGroup": "css",
+        "buildPath": "build/css/",
+        "files": [{
           "destination": "variables-color.css",
           "format": "css/variables",
           "filter": "isCategoryColor"
-        },
-        {
+        }, {
           "destination": "variables-size.css",
           "format": "css/variables",
           "filter": "isCategorySize"
-        }
-      ]
-    },
-    "cssUtilities": {
-      "buildPath": "build/utilities/",
-      "transformGroup": "css",
-      "files": [
-        {
+        }]
+      },
+      "cssUtilities": {
+        "buildPath": "build/utilities/",
+        "transformGroup": "css",
+        "files": [{
           "destination": "utilities-size.css",
           "format": "utilityClass",
           "filter": "isCategorySize"
-        },
-        {
+        }, {
           "destination": "utilities-color.css",
           "format": "utilityClass",
           "filter": "isCategoryColor"
-        }
-      ]
-    },
-    "sassUtilities": {
-      "buildPath": "build/utilities/",
-      "transformGroup": "scss",
-      "files": [
-        {
+        }]
+      },
+      "sassUtilities": {
+        "buildPath": "build/utilities/",
+        "transformGroup": "scss",
+        "files": [{
           "destination": "utilities-size.scss",
           "format": "utilityClass",
           "filter": "isCategorySize"
-        },
-        {
+        }, {
           "destination": "utilities-color.scss",
           "format": "utilityClass",
           "filter": "isCategoryColor"
-        }
-      ]
-    },
-    "js": {
-      "transformGroup": "js",
-      "buildPath": "build/js/",
-      "files": [
-        {
+        }]
+      },
+      "js": {
+        "transformGroup": "js",
+        "buildPath": "build/js/",
+        "files": [{
           "destination": "variables-color.js",
           "format": "javascript/module",
           "filter": "isCategoryColor"
-        },
-        {
+        }, {
           "destination": "variables-size.js",
           "format": "javascript/module",
           "filter": "isCategorySize"
-        }
-      ]
-    },
-    "web": {
-      "transformGroup": "js",
-      "buildPath": "build/json/",
-      "files": [
-        {
+        }]
+      },
+      "web": {
+        "transformGroup": "js",
+        "buildPath": "build/json/",
+        "files": [{
           "destination": "variables-color.json",
           "format": "json",
           "filter": "isCategoryColor"
-        },
-        {
+        }, {
           "destination": "variables-size.json",
           "format": "json",
           "filter": "isCategorySize"
-        }
-      ]
+        }]
+      }
     }
   }
-}
+  

--- a/config.json
+++ b/config.json
@@ -4,68 +4,98 @@
     "scss": {
       "transformGroup": "scss",
       "buildPath": "build/scss/",
-      "files": [{
-        "destination": "variables-color.scss",
-        "format": "scss/variables",
-        "filter": "isCategoryColor"
-      }, {
-        "destination": "variables-size.scss",
-        "format": "scss/variables",
-        "filter": "isCategorySize"
-      }]
+      "files": [
+        {
+          "destination": "variables-color.scss",
+          "format": "scss/variables",
+          "filter": "isCategoryColor"
+        },
+        {
+          "destination": "variables-size.scss",
+          "format": "scss/variables",
+          "filter": "isCategorySize"
+        }
+      ]
     },
     "css": {
       "transformGroup": "css",
       "buildPath": "build/css/",
-      "files": [{
-        "destination": "variables-color.css",
-        "format": "css/variables",
-        "filter": "isCategoryColor"
-      }, {
-        "destination": "variables-size.css",
-        "format": "css/variables",
-        "filter": "isCategorySize"
-      }]
+      "files": [
+        {
+          "destination": "variables-color.css",
+          "format": "css/variables",
+          "filter": "isCategoryColor"
+        },
+        {
+          "destination": "variables-size.css",
+          "format": "css/variables",
+          "filter": "isCategorySize"
+        }
+      ]
     },
     "cssUtilities": {
       "buildPath": "build/utilities/",
       "transformGroup": "css",
-      "files": [{
-        "destination": "utilities-size.css",
-        "format": "utilityClass",
-        "filter": "isCategorySize"
-      }, {
-        "destination": "utilities-color.css",
-        "format": "utilityClass",
-        "filter": "isCategoryColor"
-      }]
+      "files": [
+        {
+          "destination": "utilities-size.css",
+          "format": "utilityClass",
+          "filter": "isCategorySize"
+        },
+        {
+          "destination": "utilities-color.css",
+          "format": "utilityClass",
+          "filter": "isCategoryColor"
+        }
+      ]
     },
     "sassUtilities": {
       "buildPath": "build/utilities/",
       "transformGroup": "scss",
-      "files": [{
-        "destination": "utilities-size.scss",
-        "format": "utilityClass",
-        "filter": "isCategorySize"
-      }, {
-        "destination": "utilities-color.scss",
-        "format": "utilityClass",
-        "filter": "isCategoryColor"
-      }]
+      "files": [
+        {
+          "destination": "utilities-size.scss",
+          "format": "utilityClass",
+          "filter": "isCategorySize"
+        },
+        {
+          "destination": "utilities-color.scss",
+          "format": "utilityClass",
+          "filter": "isCategoryColor"
+        }
+      ]
     },
     "js": {
       "transformGroup": "js",
       "buildPath": "build/js/",
-      "files": [{
-        "destination": "variables-color.js",
-        "format": "javascript/module",
-        "filter": "isCategoryColor"
-      }, {
-        "destination": "variables-size.js",
-        "format": "javascript/module",
-        "filter": "isCategorySize"
-      }]
+      "files": [
+        {
+          "destination": "variables-color.js",
+          "format": "javascript/module",
+          "filter": "isCategoryColor"
+        },
+        {
+          "destination": "variables-size.js",
+          "format": "javascript/module",
+          "filter": "isCategorySize"
+        }
+      ]
+    },
+    "web": {
+      "transformGroup": "js",
+      "buildPath": "build/json/",
+      "files": [
+        {
+          "destination": "variables-color.json",
+          "format": "json",
+          "filter": "isCategoryColor"
+        },
+        {
+          "destination": "variables-size.json",
+          "format": "json",
+          "filter": "isCategorySize"
+        }
+      ]
     }
   }
 }
-


### PR DESCRIPTION
When trying to use this module in Typescript projects, the JS output modules don't have the same type inference that a JSON file would have. This impacts auto-completion, type checking, and TS keywords like typeof and keyof. To resolve this, I added JSON output to the config so it outputs JSON files to build/json.

I've tested this PR in the palmetto-website repo through `yarn link` in a development branch.

Here's an example of some fun TS typing stuff we can do when using JSON instead of a JS module:
![image](https://user-images.githubusercontent.com/2118649/88115460-ca14d400-cb7b-11ea-8051-4a71c6b861af.png)
