### PR TITLE
fix: set specific horizontal and vertical spacing properties only

### DIFF
--- a/build.js
+++ b/build.js
@@ -123,9 +123,9 @@ StyleDictionary.registerFormat({
               if (variation === '') {
                 output += `.${utilityClass} { ${property}: ${prop.value} }\n\n`;
               } else if (variation === 'h') {
-                output += `.${utilityClass} { ${property}: 0 ${prop.value} }\n\n`;
+                output += `.${utilityClass} { ${property}-left: ${prop.value}; ${property}-right: ${prop.value} }\n\n`;
               } else if (variation === 'v') {
-                output += `.${utilityClass} { ${property}: ${prop.value} 0 }\n\n`;
+                output += `.${utilityClass} { ${property}-top: ${prop.value}; ${property}-bottom: ${prop.value} }\n\n`;
               }
             }
           });


### PR DESCRIPTION
before the horizontal and vertical css utility classes set the following:

```css
.m-v-md { margin: 1rem 0 }
```

Trying to use both horizontal and vertical spacing classes results in collisions because the `0` horizontal margin in the example above is getting set by a css class that should only be concerned with vertical styles.

This PR makes it so that horizontal and vertical spacing utility classes set only their css properties.

```css
.m-v-md { margin-top: 1rem; margin-bottom: 1rem }
.m-h-lg { margin-left: 1.5rem; margin-right: 1.5rem }
```