### PR TITLE
feat: expand brand color palette with lightest, darkest options

### DIFF
--- a/properties/color/base.json
+++ b/properties/color/base.json
@@ -22,7 +22,7 @@
         "400"  : { "value": "#FFAA1A", "attributes": {"font": "base"}},
         "500"  : { "value": "#E68900", "attributes": {"font": "base"}},
         "600"  : { "value": "#B37600", "attributes": {"font": "base"}},
-        "700"  : { "value": "#4F3D00", "attributes": {"font": "inverse"}},
+        "700"  : { "value": "#815D00", "attributes": {"font": "inverse"}},
         "800"  : { "value": "#4F3D00", "attributes": {"font": "inverse"}},
         "900"  : { "value": "#1F1600", "attributes": {"font": "inverse"}}
       },
@@ -105,7 +105,7 @@
         "300"  : { "value": "#A0ADA4", "attributes": {"font": "base"}},
         "400"  : { "value": "#86968A", "attributes": {"font": "base"}},
         "500"  : { "value": "#6C7C70", "attributes": {"font": "base"}},
-        "600"  : { "value": "#546158", "attributes": {"font": "inverse"}},
+        "600"  : { "value": "#4D524F", "attributes": {"font": "inverse"}},
         "700"  : { "value": "#3C453E", "attributes": {"font": "inverse"}},
         "800"  : { "value": "#2A2D2B", "attributes": {"font": "inverse"}},
         "900"  : { "value": "#080F08", "attributes": {"font": "inverse"}}

--- a/properties/color/brand.json
+++ b/properties/color/brand.json
@@ -2,67 +2,83 @@
   "color": {
     "brand": {
       "primary": {
+        "lightest": { "value": "{color.base.green.50.value}" },
         "lighter": { "value": "{color.base.green.100.value}" },
         "light":   { "value": "{color.base.green.300.value}" },
-        "base":    { "value": "{color.base.green.500.value}" },
+        "base":    { "value": "{color.base.green.600.value}" },
         "dark":    { "value": "{color.base.green.700.value}" },
-        "darker":  { "value": "{color.base.green.800.value}" }
+        "darker":  { "value": "{color.base.green.800.value}" },
+        "darkest":  { "value": "{color.base.green.900.value}" }
       },
 
       "secondary": {
+        "lightest": { "value": "{color.base.blue.50.value}" },
         "lighter": { "value": "{color.base.blue.100.value}" },
         "light":   { "value": "{color.base.blue.300.value}" },
         "base":    { "value": "{color.base.blue.500.value}" },
-        "dark":    { "value": "{color.base.blue.700.value}" },
-        "darker":  { "value": "{color.base.blue.800.value}" }
+        "dark":    { "value": "{color.base.blue.600.value}" },
+        "darker":  { "value": "{color.base.blue.700.value}" },
+        "darkest":  { "value": "{color.base.blue.800.value}" }
       },
 
       "tertiary": {
+        "lightest": { "value": "{color.base.purple.50.value}" },
         "lighter": { "value": "{color.base.purple.100.value}" },
         "light":   { "value": "{color.base.purple.300.value}" },
         "base":    { "value": "{color.base.purple.500.value}" },
-        "dark":    { "value": "{color.base.purple.700.value}" },
-        "darker":  { "value": "{color.base.purple.800.value}" }
+        "dark":    { "value": "{color.base.purple.600.value}" },
+        "darker":  { "value": "{color.base.purple.700.value}" },
+        "darkest":  { "value": "{color.base.purple.800.value}" }
       },
 
       "grey": {
+        "lightest": { "value": "{color.base.grey.50.value}" },
         "lighter": { "value": "{color.base.grey.100.value}" },
         "light":   { "value": "{color.base.grey.300.value}" },
         "base":    { "value": "{color.base.grey.500.value}" },
-        "dark":    { "value": "{color.base.grey.700.value}" },
-        "darker":  { "value": "{color.base.grey.800.value}" }
+        "dark":    { "value": "{color.base.grey.600.value}" },
+        "darker":  { "value": "{color.base.grey.700.value}" },
+        "darkest":  { "value": "{color.base.grey.800.value}" }
       },
 
       "success": {
+        "lightest": { "value": "{color.base.green.50.value}" },
         "lighter": { "value": "{color.base.green.100.value}" },
         "light":   { "value": "{color.base.green.300.value}" },
         "base":    { "value": "{color.base.green.500.value}" },
-        "dark":    { "value": "{color.base.green.700.value}" },
-        "darker":  { "value": "{color.base.green.800.value}" }
+        "dark":    { "value": "{color.base.green.600.value}" },
+        "darker":  { "value": "{color.base.green.700.value}" },
+        "darkest":  { "value": "{color.base.green.800.value}" }
       },
 
       "warning": {
+        "lightest": { "value": "{color.base.orange.50.value}" },
         "lighter": { "value": "{color.base.orange.100.value}" },
         "light":   { "value": "{color.base.orange.300.value}" },
         "base":    { "value": "{color.base.orange.500.value}" },
-        "dark":    { "value": "{color.base.orange.700.value}" },
-        "darker":  { "value": "{color.base.orange.800.value}" }
+        "dark":    { "value": "{color.base.orange.600.value}" },
+        "darker":  { "value": "{color.base.orange.700.value}" },
+        "darkest":  { "value": "{color.base.orange.800.value}" }
       },
 
       "danger": {
+        "lightest": { "value": "{color.base.red.50.value}" },
         "lighter": { "value": "{color.base.red.100.value}" },
         "light":   { "value": "{color.base.red.300.value}" },
         "base":    { "value": "{color.base.red.500.value}" },
-        "dark":    { "value": "{color.base.red.700.value}" },
-        "darker":  { "value": "{color.base.red.800.value}" }
+        "dark":    { "value": "{color.base.red.600.value}" },
+        "darker":  { "value": "{color.base.red.700.value}" },
+        "darkest":  { "value": "{color.base.red.800.value}" }
       },
 
       "info": {
+        "lightest": { "value": "{color.base.blue.50.value}" },
         "lighter": { "value": "{color.base.blue.100.value}" },
         "light":   { "value": "{color.base.blue.300.value}" },
         "base":    { "value": "{color.base.blue.500.value}" },
-        "dark":    { "value": "{color.base.blue.700.value}" },
-        "darker":  { "value": "{color.base.blue.800.value}" }
+        "dark":    { "value": "{color.base.blue.600.value}" },
+        "darker":  { "value": "{color.base.blue.700.value}" },
+        "darkest":  { "value": "{color.base.blue.800.value}" }
       },
 
       "dark": {

--- a/properties/color/font.json
+++ b/properties/color/font.json
@@ -1,19 +1,22 @@
 {
   "color": {
     "font": {
-      "base": { "value": "{color.brand.grey.dark.value}" },
-      "inverse": { "value": "{color.base.black.value}" },
+      "base": { "value": "{color.brand.dark.base.value}" },
+      "inverse": { "value": "{color.brand.light.base.value}" },
       "primary": { "value": "{color.brand.primary.base.value}" },
       "secondary": { "value": "{color.brand.secondary.base.value}" },
       "tertiary": { "value": "{color.brand.tertiary.base.value}" },
       "success": { "value": "{color.brand.success.base.value}" },
       "warning": { "value": "{color.brand.warning.base.value}" },
       "danger": { "value": "{color.brand.danger.base.value}" },
+      "info": { "value": "{color.brand.info.base.value}" },
       "grey": { "value": "{color.brand.grey.base.value}" },
+      "grey-lightest": { "value": "{color.brand.grey.lightest.value}" },
       "grey-light": { "value": "{color.brand.grey.light.value}" },
       "grey-lighter": { "value": "{color.brand.grey.lighter.value}" },
       "grey-dark": { "value": "{color.brand.grey.dark.value}" },
-      "grey-darker": { "value": "{color.brand.grey.darker.value}" }
+      "grey-darker": { "value": "{color.brand.grey.darker.value}" },
+      "grey-darkest": { "value": "{color.brand.grey.darkest.value}" }
     }
   }
 }


### PR DESCRIPTION
- this expands the brand colors to include lightest and darkest options.
- corrects the primary base color value (used in buttons)
- updates the dark through darkest brand colors to off all brand colors.

In a separate PR, we will stop publishing the base colors values.

Result:
<img width="1219" alt="Screen Shot 2020-07-24 at 7 47 33 AM" src="https://user-images.githubusercontent.com/1447339/88403873-f601a680-cd81-11ea-8d6a-da1e0103f3dd.png">
