### PR TITLE
add custom transform for kebab-case

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,5 @@
 const StyleDictionary = require('style-dictionary');
+const { kebabCase } = require('./utils/kebabCase');
 
 console.log('Build started...');
 console.log('\n==============================================');
@@ -133,13 +134,21 @@ StyleDictionary.registerTransform({
   },
 });
 
+StyleDictionary.registerTransform({
+  name: 'name/cti/custom-kebab',
+  type: 'name',
+  transformer: function(prop, options) {
+    return kebabCase([options.prefix].concat(prop.path).join(' '));
+  },
+});
+
 // APPLY THE CONFIGURATION
 // IMPORTANT: the registration of custom transforms
 // needs to be done _before_ applying the configuration
 StyleDictionaryExtended = StyleDictionary.extend('./config.json');
 
-
 // FINALLY, BUILD ALL THE PLATFORMS
+StyleDictionaryExtended.cleanAllPlatforms();
 StyleDictionaryExtended.buildAllPlatforms();
 
 

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "source": ["properties/**/*.json"],
   "platforms": {
     "scss": {
-      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
+      "transforms": ["attribute/cti", "name/cti/custom-kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "buildPath": "build/scss/",
       "files": [{
         "destination": "variables-color.scss",
@@ -15,7 +15,7 @@
       }]
     },
     "css": {
-      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
+      "transforms": ["attribute/cti", "name/cti/custom-kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "buildPath": "build/css/",
       "files": [{
         "destination": "variables-color.css",
@@ -29,7 +29,7 @@
     },
     "cssUtilities": {
       "buildPath": "build/utilities/",
-      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
+      "transforms": ["attribute/cti", "name/cti/custom-kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "files": [{
         "destination": "utilities-size.css",
         "format": "utilityClass",
@@ -42,7 +42,7 @@
     },
     "sassUtilities": {
       "buildPath": "build/utilities/",
-      "transforms": ["attribute/cti", "name/cti/kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
+      "transforms": ["attribute/cti", "name/cti/custom-kebab", "time/seconds", "content/icon", "size/use-unit", "color/css"],
       "files": [{
         "destination": "utilities-size.scss",
         "format": "utilityClass",

--- a/utils/kebabCase.js
+++ b/utils/kebabCase.js
@@ -1,0 +1,30 @@
+/**
+ * Given a string, converts it to kebab case (lowercase, hyphen-separated). For example,
+ * "makeFoo" becomes "make-foo", and "a Multi Word string" becomes "a-multi-word-string".
+ *
+ * @param {string} string Your input string.
+ * @returns {string} Kebab-cased string.
+ */
+function kebabCase(string) {
+  var result = string;
+
+  // Convert camelCase capitals to kebab-case.
+  result = result.replace(/([a-z][A-Z])/g, function (match) {
+    return match.substr(0, 1) + '-' + match.substr(1, 1).toLowerCase();
+  });
+
+  // Convert non-camelCase capitals to lowercase.
+  result = result.toLowerCase();
+
+  // Convert non-alphanumeric characters to hyphens
+  result = result.replace(/[^-a-z0-9]+/g, '-');
+
+  // Remove hyphens from both ends
+  result = result.replace(/^-+/, '').replace(/-+$/, '');
+
+  return result;
+}
+
+module.exports = {
+  kebabCase,
+};


### PR DESCRIPTION
This should fix badly transformed variable names when the name includes a number. `2xl` for example.