### PR TITLE
feat: add font weight tokens and utility classes

### DIFF
--- a/build.js
+++ b/build.js
@@ -46,7 +46,7 @@ const FIGMA_TOKENS_DOCUMENT = 'abGRptpr7iPaMsXdEPVm6W';
  * Ideally the figma file version _label_ and the npm package version will match
  * but it is not required.
  */
-const FIGMA_FILE_VERSION = '499014211';
+const FIGMA_FILE_VERSION = '499055820';
 
 // APPLY THE CONFIGURATION
 // IMPORTANT: the registration of custom transforms

--- a/formats/utilityClass/utilityClass.js
+++ b/formats/utilityClass/utilityClass.js
@@ -92,6 +92,13 @@ const utilities = [{
     cssProp: 'border',
     variations: ['', 'top', 'right', 'bottom', 'left', 'h', 'v'],
   },
+  {
+    name: 'font-weight',
+    tokenCategory: 'size',
+    tokenType: 'font-weight',
+    cssProp: 'font-weight',
+    variations: [''],
+  },
 ];
 
 const nestInsideMediaQuery = (css, breakpoint) => {


### PR DESCRIPTION
adds the following from our figma file: 

```
  --size-font-weight-black: 900;
  --size-font-weight-bold: 700;
  --size-font-weight-regular: 400;
  --size-font-weight-light: 300;

// responsive versions of :
.font-weight-black { font-weight: 900; }
.font-weight-bold { font-weight: 700; }
.font-weight-regular { font-weight: 400; }
.font-weight-light { font-weight: 300; }
```