### PR TITLE
feat(colors): transparent color

### DIFF
--- a/build.js
+++ b/build.js
@@ -52,7 +52,7 @@ const FIGMA_TOKENS_DOCUMENT = 'abGRptpr7iPaMsXdEPVm6W';
  * Ideally the figma file version _label_ and the npm package version will match
  * but it is not required.
  */
-const FIGMA_FILE_VERSION = '684180290';
+const FIGMA_FILE_VERSION = '762372273';
 
 
 /**


### PR DESCRIPTION
this adds a transparent brand color it can be used as a variable, but the main use case is utility classes for things like backgrounds and borders where necessary.

the color was added to brand colors in the FIGMA file, since that is its most low-friction point of entry, but I understand it may not be a "brand" color per se so we can discuss if an alternative is preferred.

https://www.figma.com/file/abGRptpr7iPaMsXdEPVm6W/Design-Tokens?version-id=762372273&node-id=0%3A1