### PR TITLE
fix: Figma token env variable error message now says to set the right env variable

### DIFF
--- a/utils/getFigmaDocument/getFigmaDocument.js
+++ b/utils/getFigmaDocument/getFigmaDocument.js
@@ -4,7 +4,7 @@ require('dotenv').config();
 if (!process.env.FIGMA_PERSONAL_ACCESS_TOKEN) {
   throw new Error(`Put your Figma token in a .env in the root directory of this directory.
   The .env file should look like this:
-  PERSONAL_ACCESS_TOKEN='xxxx'`);
+  FIGMA_PERSONAL_ACCESS_TOKEN='xxxx'`);
 }
 
 const requestConfig = {


### PR DESCRIPTION
I was poking around design tokens and couldn't figure out why my build wasn't working even though I was doing what the message said to!