### PR TITLE
fix(variables): custom format for font css variables

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,6 +6,8 @@ const parseFigmaDocumentTokens = require('./utils/parseFigmaDocumentTokens/parse
 const mapSemanticColors = require('./utils/mapSemanticColors/mapSemanticColors');
 const dictionaryConfig = require('./config.json');
 const utilityClass = require('./formats/utilityClass/utilityClass');
+const cssVariablesFont = require('./formats/cssVariablesFont/cssVariablesFont');
+const scssVariablesFont = require('./formats/scssVariablesFont/scssVariablesFont');
 const useSizeUnit = require('./transforms/useSizeUnit/useSizeUnit');
 const customKebab = require('./transforms/customKebab/customKebab');
 const createIconComponents = require('./utils/createIconComponents/createIconComponents');
@@ -36,6 +38,8 @@ StyleDictionary.registerFilter({
 
 // Custom Formats
 StyleDictionary.registerFormat(utilityClass);
+StyleDictionary.registerFormat(cssVariablesFont);
+StyleDictionary.registerFormat(scssVariablesFont);
 
 // Custom Transforms
 StyleDictionary.registerTransform(useSizeUnit);
@@ -55,7 +59,7 @@ const FIGMA_TOKENS_DOCUMENT = 'abGRptpr7iPaMsXdEPVm6W';
  * Ideally the figma file version _label_ and the npm package version will match
  * but it is not required.
  */
-const FIGMA_FILE_VERSION = '1421698954';
+const FIGMA_FILE_VERSION = '1472455088';
 
 /**
  * Read tokens from FIGMA file.

--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
         },
         {
           "destination": "variables-asset.scss",
-          "format": "scss/variables",
+          "format": "scss/variables/font",
           "filter": "isCategoryAsset"
         }
       ]
@@ -37,7 +37,7 @@
         },
         {
           "destination": "variables-asset.css",
-          "format": "css/variables",
+          "format": "css/variables/font",
           "filter": "isCategoryAsset"
         }
       ]

--- a/formats/cssVariablesFont/cssVariablesFont.js
+++ b/formats/cssVariablesFont/cssVariablesFont.js
@@ -1,0 +1,20 @@
+const createFileHeader = require('../../utils/createFileHeader/createFileHeader');
+const addNewLines = require('../../utils/addNewLines/addNewLines');
+const variablesWithPrefix = require('../../utils/variablesWithPrefix/variablesWithPrefix');
+
+
+const cssVariablesFont = {
+  name: 'css/variables/font',
+  formatter: function (dictionary) {
+    let output = createFileHeader();
+    
+    output += addNewLines(':root {', 1);
+    output += variablesWithPrefix('  --', dictionary.allProperties)
+    output = addNewLines(output, 1);
+    output = addNewLines(`${output}}`, 1);
+
+    return output;
+  },
+};
+
+module.exports = cssVariablesFont;

--- a/formats/scssVariablesFont/scssVariablesFont.js
+++ b/formats/scssVariablesFont/scssVariablesFont.js
@@ -1,0 +1,20 @@
+const createFileHeader = require('../../utils/createFileHeader/createFileHeader');
+const addNewLines = require('../../utils/addNewLines/addNewLines');
+const variablesWithPrefix = require('../../utils/variablesWithPrefix/variablesWithPrefix');
+
+
+const scssVariablesFont = {
+  name: 'scss/variables/font',
+  formatter: function (dictionary) {
+    let output = createFileHeader();
+    
+    output += addNewLines(':root {', 1);
+    output += variablesWithPrefix('  $', dictionary.allProperties)
+    output = addNewLines(output, 1);
+    output = addNewLines(`${output}}`, 1);
+
+    return output;
+  },
+};
+
+module.exports = scssVariablesFont;

--- a/utils/variablesWithPrefix/variablesWithPrefix.js
+++ b/utils/variablesWithPrefix/variablesWithPrefix.js
@@ -1,0 +1,19 @@
+function variablesWithPrefix(prefix, properties, commentStyle) {
+  return properties.map(function(prop) {
+      var to_ret_prop = prefix + prop.name + ': ' + prop.value + ';';
+
+      if (prop.comment) {
+        if (commentStyle === 'short') {
+          to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
+        } else {
+          to_ret_prop = to_ret_prop.concat(' /* ' + prop.comment + ' */');
+        }
+      }
+
+      return to_ret_prop;
+    })
+    .filter(function(strVal) { return !!strVal })
+    .join('\n');
+}
+
+module.exports = variablesWithPrefix;


### PR DESCRIPTION
This PR adds a custom format to handle font asset strings since the default css/variables format from style dictionary forcefully wraps all our values in quotes which makes the font syntax incorrect.