### PR TITLE
fix: primary and danger codes

### DIFF
--- a/build.js
+++ b/build.js
@@ -59,7 +59,7 @@ const FIGMA_TOKENS_DOCUMENT = 'KCJ2oUyX2sAtYuAmjmF4lg';
  * Ideally the figma file version _label_ and the npm package version will match
  * but it is not required.
  */
-const FIGMA_FILE_VERSION = '1534973438';
+const FIGMA_FILE_VERSION = '1568094992';
 
 /**
  * Read tokens from FIGMA file.


### PR DESCRIPTION
- new figma version
- fix: 200-400 danger values, 300 primary value