### PR TITLE
fix: Allow individual icon imports

### DIFF
--- a/utils/createIconComponents/createIconComponents.js
+++ b/utils/createIconComponents/createIconComponents.js
@@ -44,6 +44,7 @@ async function createIconComponents() {
 
   let iconComponentsIndexFile = '';
   let iconComponentsImports = '';
+  let iconComponentsIndividualExports = "";
   let iconComponentsExport = `const icons = {\n`;
   iconComponentsIndexFile = createFileHeader(iconComponentsIndexFile);
 
@@ -53,6 +54,11 @@ async function createIconComponents() {
     iconComponentsImports = iconComponentsImports.concat(
       `import ${componentName} from './${componentName}';\n`,
     );
+
+    iconComponentsIndividualExports = iconComponentsIndividualExports.concat(
+      `export {${componentName}};\n`
+    );
+
     iconComponentsExport = iconComponentsExport.concat(
       indentLine(`'${iconName}': ${componentName},\n`, 2),
     );
@@ -60,6 +66,8 @@ async function createIconComponents() {
 
   iconComponentsExport = iconComponentsExport.concat('};\n\n export default icons;\n');
   iconComponentsIndexFile = iconComponentsIndexFile.concat(iconComponentsImports);
+  iconComponentsIndexFile = iconComponentsIndexFile.concat("\n");
+  iconComponentsIndexFile = iconComponentsIndexFile.concat(iconComponentsIndividualExports);
   iconComponentsIndexFile = iconComponentsIndexFile.concat('\n');
   iconComponentsIndexFile = iconComponentsIndexFile.concat(iconComponentsExport);
 


### PR DESCRIPTION
I was tinkering with making Palmetto Components' `Icon` tree-shakeable and this is a first step that I landed on. I haven't messed with the Icon component in P-C to test that this actually works. Wanted to open this PR to formally start discussion about this.

Relevant issue in P-C repo: https://github.com/palmetto/palmetto-components/issues/593

This seems to be back-compat with existing implementation. Tested with `npm link` in p-c with storybook. Need to try linking to a dependent of p-c to ensure that still works.

Importing an icon through `import { IconName } from '@palmetto/palmetto-design-tokens/build/icons/react' seems to work in p-c storybook as well.