### PR TITLE
fix: add explicit permission keys for release action

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Builds appear to be failing due to insufficient permissions. 

https://github.com/palmetto/palmetto-design-tokens/runs/6462281356?check_suite_focus=true

Similar to what happened here when our our github permission model changed. 
https://github.com/palmetto/palmetto-components/pull/773