### PR TITLE
build: stop publishing to github packages

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -31,17 +31,3 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
         run: yarn semantic-release
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@palmetto'
-      - name: Release to GitHub Packages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          FIGMA_PERSONAL_ACCESS_TOKEN: ${{ secrets.FIGMA_PERSONAL_ACCESS_TOKEN }}
-          NPM_CONFIG_REGISTRY: https://npm.pkg.github.com/
-        run: yarn semantic-release


### PR DESCRIPTION
Giving up on this (for now), since calling semantic-release twice on the same action is a noop.